### PR TITLE
fix: minishell execute file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.i*86
 *.x86_64
 *.hex
+minishell
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
gitignoreに実行ファイルを追加しました。
PRの練習を兼ねてます。