### PR TITLE
fix: env -i ./minishell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/01/08 20:22:12 by tkomatsu          #+#    #+#              #
-#    Updated: 2021/02/12 19:33:48 by kefujiwa         ###   ########.fr        #
+#    Updated: 2021/02/15 22:56:04 by tkomatsu         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -81,6 +81,7 @@ EXE_SRCS = $(addprefix $(EXE_DIR), $(EXE_FILES))
 
 UTIL_DIR = utils/
 UTIL_FILES = clear_tokens.c \
+			 exit_perror.c \
 			 ft_getenv.c \
 			 ft_perror.c \
 			 ft_putenv.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/08 21:13:49 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/13 14:18:21 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/15 22:55:32 by tkomatsu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,6 +91,7 @@ int		msh_unset(char **args);
 */
 
 void	clear_tokens(t_token **tokens);
+void	exit_perror(char *err_msg, int exit_status);
 int		token_size(t_token *tokens);
 char	*ft_getenv(const char *name);
 void	ft_perror(char *s);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: kefujiwa <kefujiwa@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/08 21:12:29 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/13 13:36:18 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/15 22:56:40 by tkomatsu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,28 +30,25 @@ void	ft_envcpy(void)
 	extern char	**environ;
 	int			i;
 	int			envlen;
-	int			shlvl;
+	static int	shlvl = 1;
 
 	envlen = 0;
 	while (environ[envlen])
 		envlen++;
 	if (!(g_env = ft_calloc(envlen + 1, sizeof(char*))))
-	{
-		perror("envcpy");
-		exit(1);
-	}
+		exit_perror("envcpy", 1);
 	i = 0;
 	while (environ[i])
 	{
 		if (!(g_env[i] = ft_strdup(environ[i])))
-		{
-			perror("envcpy");
-			exit(1);
-		}
+			exit_perror("envcpy", 1);
 		i++;
 	}
-	shlvl = ft_atoi(ft_getenv("SHLVL")) + 1;
+	if (ft_getenv("SHLVL"))
+		shlvl = ft_atoi(ft_getenv("SHLVL")) + 1;
 	ft_setenv("SHLVL", ft_itoa(shlvl), 1);
+	ft_setenv("PWD", getcwd(NULL, 0), 1);
+	ft_setenv("OLDPWD", NULL, 1);
 }
 
 void	minish_loop(void)

--- a/srcs/utils/exit_perror.c
+++ b/srcs/utils/exit_perror.c
@@ -1,0 +1,19 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exit_perror.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/02/15 22:54:01 by tkomatsu          #+#    #+#             */
+/*   Updated: 2021/02/15 22:54:56 by tkomatsu         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	exit_perror(char *str_msg, int exit_status)
+{
+	perror(str_msg);
+	exit(exit_status);
+}


### PR DESCRIPTION
環境変数なしで実行された時にセグフォするのを解決

fix #54

`ft_envcpy()`で環境変数をコピーする際にセグフォが発生していた。
`ft_atoi()`に`NULL`が渡されるとセグフォする。
`atoi()`でも同様にセグフォする仕様のため、minishell内のコードで対応。
それに合わせて、環境変数がない状態で実行されても最低限以下の環境変数の宣言はされるように修正。
* OLDPWD(宣言のみ)
* PWD
* SHLVL
