### PR TITLE
fix(expand_environ.c): fix SEGV Error

### DIFF
--- a/srcs/parse/expand_environ.c
+++ b/srcs/parse/expand_environ.c
@@ -6,7 +6,7 @@
 /*   By: kefujiwa <kefujiwa@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 15:29:24 by kefujiwa          #+#    #+#             */
-/*   Updated: 2021/02/19 20:46:54 by tkomatsu         ###   ########.fr       */
+/*   Updated: 2021/02/19 22:29:56 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ static char	*get_var(char *str, int len)
 	else
 	{
 		ft_free(tmp);
-		if (!(ret = ft_strdup(ft_getenv(tmp))))
+		if (!(ret = ft_strdup(env)))
 			return (NULL);
 	}
 	return (ret);


### PR DESCRIPTION
#65 で起票したセグフォエラーの対応を行いました。
ご確認お願いいたします！

事象としては、debugモードでminishellを起動し、存在する環境変数を展開するコマンドを打つとセグフォが起きるというものです。
※通常モードだとエラーが起きず正常に処理される。
例：echo $PWD

修正箇所は、expand_environ.c の47行目のみです。
これで、セグフォは発生しなくなりました。
念のため、問題がなくなっているか確認お願いいたします。