### PR TITLE
feat(multiline input): - add multiline input feature with specific error handling

### DIFF
--- a/includes/error.h
+++ b/includes/error.h
@@ -6,7 +6,7 @@
 /*   By: kefujiwa <kefujiwa@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/19 02:46:21 by kefujiwa          #+#    #+#             */
-/*   Updated: 2021/02/21 15:32:45 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/22 13:04:50 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 */
 # define E_MINI 200
 # define E_CMD 201
-# define E_QUOTE 202
+# define E_EOF 202
 # define E_VALID 203
 # define E_NUMERIC 204
 # define E_ARGS 205

--- a/srcs/read/read_stdin.c
+++ b/srcs/read/read_stdin.c
@@ -6,37 +6,46 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/18 22:34:03 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/19 23:47:04 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/22 12:59:05 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "read.h"
 
-/*
-static void	add_next_line(char **line, int flag)
+static int	output_eof_err(int flag)
+{
+	if (flag == QUOTE)
+		ft_putendl_fd("minish: unexpected EOF while looking for matching `\''"
+				, STDERR);
+	else if (flag == DQUOTE)
+		ft_putendl_fd("minish: unexpected EOF while looking for matching `\"'"
+				, STDERR);
+	errno = E_EOF;
+	ft_perror("minish: syntax error");
+	return (INVALID_INPUT);
+}
+
+static int	add_next_line(char **line, int flag)
 {
 	int		ret;
 	char	*new;
 	char	*put_nl;
 	char	*tmp;
 
-	if (flag == QUOTE)
-		ft_putstr_fd("quote> ", STDOUT);
-	else if (flag == DQUOTE)
-		ft_putstr_fd("dquote> ", STDOUT);
-	if ((ret = get_next_line(0, &tmp)) < 0)
-	{
-		ft_perror("get_next_line");
-		exit(EXIT_FAILURE);
-	}
+	if (flag == QUOTE || flag == DQUOTE)
+		ft_putstr_fd("> ", STDOUT);
+	if ((ret = get_next_input(0, &tmp)) < 0)
+		exit_perror("get_next_input", EXIT_FAILURE);
+	if (!ret)
+		return (output_eof_err(flag));
 	put_nl = ft_strjoin("\n", tmp);
 	free(tmp);
 	new = ft_strjoin(*line, put_nl);
 	free(put_nl);
 	free(*line);
 	*line = new;
+	return (VALID_INPUT);
 }
-*/
 
 static int	is_bad_quote(char *line)
 {
@@ -72,16 +81,8 @@ int			read_stdin(char **line)
 		ft_putendl_fd("exit", STDOUT);
 		exit(EXIT_SUCCESS);
 	}
-	if (is_bad_quote(*line))
-	{
-		errno = E_QUOTE;
-		ft_putstr_fd("minish: ", STDERR);
-		ft_perror(*line);
-		return (INVALID_INPUT);
-	}
-	/*
 	while ((ret = is_bad_quote(*line)))
-		add_next_line(line, ret);
-	*/
+		if (add_next_line(line, ret) == INVALID_INPUT)
+			return (INVALID_INPUT);
 	return (VALID_INPUT);
 }

--- a/srcs/utils/ft_perror.c
+++ b/srcs/utils/ft_perror.c
@@ -6,7 +6,7 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/22 23:36:39 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/20 00:00:32 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/22 13:05:21 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,8 @@ static char	*ft_strerror(void)
 		ft_strlcpy(str, "minishell error", 100);
 	else if (errno == E_CMD)
 		ft_strlcpy(str, "command not found", 100);
-	else if (errno == E_QUOTE)
-		ft_strlcpy(str, "no closing quotation", 100);
+	else if (errno == E_EOF)
+		ft_strlcpy(str, "unexpected end of file", 100);
 	else if (errno == E_VALID)
 		ft_strlcpy(str, "not a valid identifier", 100);
 	else if (errno == E_NUMERIC)


### PR DESCRIPTION
@tkomatsu 
minishell実装の終盤に差し掛かってきたので、以前pendingしていたmultilineの対応を入れてみました。
挙動を確認したところ、他の機能に悪影響を与えるような点は見受けられませんでしたがもし懸念点あればご指摘ください。

下記エラーパターンにも対応。
```sh
▼dquote 待ち受け中にEOF
bash-3.2$ echo "aaaaaaaa
>
> bash: unexpected EOF while looking for matching `"'
bash: syntax error: unexpected end of file

▼quote 待ち受け中にEOF
bash-3.2$ echo 'aaaaaaaa
>
> bash: unexpected EOF while looking for matching `''
bash: syntax error: unexpected end of file
```