### PR TITLE
fix(exec_path): fix segv error

### DIFF
--- a/srcs/execute/launch.c
+++ b/srcs/execute/launch.c
@@ -6,7 +6,7 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/10 22:52:44 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/21 15:19:38 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/02/22 15:27:33 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,8 @@ static char	*exec_path(char *cmd)
 	int		i;
 
 	path = ft_split(ft_getenv("PATH"), ':');
+	if (!path)
+		return (NULL);
 	i = 0;
 	while (path[i])
 	{


### PR DESCRIPTION
以下のエラーを解消しました！
些細な修正ですが、ご確認お願いいたします！

```bash
minishell$ unset PATH
minishell$ ls
AddressSanitizer:DEADLYSIGNAL
=================================================================
==42011==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x0001096e138f bp 0x7ffee6529ff0 sp 0x7ffee6529fb0 T0)
==42011==The signal is caused by a READ memory access.
==42011==Hint: address points to the zero page.
    #0 0x1096e138f in exec_path launch.c:37
    #1 0x1096e0cd3 in launch launch.c:82
    #2 0x1096df143 in execmd execmd.c:37
    #3 0x1096dd31b in run_cmd run_cmd.c:27
    #4 0x1096ddeeb in child_proc run_pipeline.c:29
    #5 0x1096ddaee in exec_pipeline run_pipeline.c:68
    #6 0x1096dd6a5 in run_pipeline run_pipeline.c:84
    #7 0x1096dc815 in parse_exec parse_exec.c:64
    #8 0x1096d8a08 in minish_loop minishell.c:73
    #9 0x1096d8b68 in main minishell.c:84
    #10 0x7fff6c6d7cc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

==42011==Register values:
rax = 0x0000000000000000  rbx = 0x00007ffee652a120  rcx = 0x0000100000000000  rdx = 0x0000100000000000
rdi = 0x0000000000000000  rsi = 0x000000000000003a  rbp = 0x00007ffee6529ff0  rsp = 0x00007ffee6529fb0
 r8 = 0x00001c04000000ea   r9 = 0x0000100000000000  r10 = 0xffffffffffffffff  r11 = 0x00000fffffffffff
r12 = 0x0000000000000000  r13 = 0x0000000000000000  r14 = 0x0000000000000000  r15 = 0x0000000000000000
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV launch.c:37 in exec_path
==42011==ABORTING
```