### PR TITLE
feat(shlvl): add conditions for shlvl; when shlvl is minus, is 1000, …

### DIFF
--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: kefujiwa <kefujiwa@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/08 21:12:29 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/22 17:38:58 by tkomatsu         ###   ########.fr       */
+/*   Updated: 2021/02/22 18:01:47 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,12 +16,36 @@ char	**g_env;
 pid_t	g_pid;
 int		g_status;
 
+void	set_shlvl(void)
+{
+	int		shlvl;
+	char	*level;
+
+	shlvl = ft_atoi(ft_getenv("SHLVL")) + 1;
+	if (shlvl < 0)
+		ft_setenv("SHLVL", "0", 1);
+	else if (shlvl == 1000)
+		ft_setenv("SHLVL", "", 1);
+	else if (shlvl > 1000)
+	{
+		ft_putstr_fd("minish: warning: shell level (", STDERR);
+		ft_putnbr_fd(shlvl, STDERR);
+		ft_putendl_fd(") too high, resetting to 1", STDERR);
+		ft_setenv("SHLVL", "1", 1);
+	}
+	else
+	{
+		level = ft_itoa(shlvl);
+		ft_setenv("SHLVL", level, 1);
+		free(level);
+	}
+}
+
 void	ft_envcpy(void)
 {
 	extern char	**environ;
 	int			i;
 	int			envlen;
-	static int	shlvl = 1;
 
 	envlen = 0;
 	while (environ[envlen])
@@ -36,8 +60,9 @@ void	ft_envcpy(void)
 		i++;
 	}
 	if (ft_getenv("SHLVL"))
-		shlvl = ft_atoi(ft_getenv("SHLVL")) + 1;
-	ft_setenv("SHLVL", ft_itoa(shlvl), 1);
+		set_shlvl();
+	else
+		ft_setenv("SHLVL", "1", 1);
 	ft_setenv("PWD", getcwd(NULL, 0), 1);
 	ft_setenv("OLDPWD", NULL, 1);
 }


### PR DESCRIPTION
課題とは直接関係ないですが、遊び心でSHLVLの場合分け処理を追加してみました。
以下のパターンに対応しています。

```
▼SHLVLが負の値の場合、SHLVLを0に初期化
env -i SHLVL=-10 bash
bash-3.2$ export
declare -x OLDPWD
declare -x PWD="/Users/kefujiwa/Work/42Tokyo/42cursus/1.in-progress/minishell"
declare -x SHLVL="0"

▼SHLVLが1000の場合、SHLVLをヌル文字に
env -i SHLVL=999 bash
bash-3.2$ export
declare -x OLDPWD
declare -x PWD="/Users/kefujiwa/Work/42Tokyo/42cursus/1.in-progress/minishell"
declare -x SHLVL=""

▼SHLVLが1000を超える場合、SHLVLを1に初期化
bash-3.2$ env -i SHLVL=1200 bash
bash: warning: shell level (1201) too high, resetting to 1
bash-3.2$ export
declare -x OLDPWD
declare -x PWD="/Users/kefujiwa/Work/42Tokyo/42cursus/1.in-progress/minishell"
declare -x SHLVL="1"
```