### PR TITLE
fix(expand_tokens.c): fix memory leak

### DIFF
--- a/srcs/parse/expand_tokens.c
+++ b/srcs/parse/expand_tokens.c
@@ -6,16 +6,18 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/11 18:17:47 by kefujiwa          #+#    #+#             */
-/*   Updated: 2021/03/04 01:29:31 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/03/04 13:18:23 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parse.h"
 
-static void	remove_word(t_token *token)
+static void	remove_word(t_token *token, char *new)
 {
 	free(token->word);
 	token->word = NULL;
+	if (new)
+		free(new);
 }
 
 static char	*strjoin_free(char *new, char *str, int type)
@@ -50,7 +52,7 @@ static void	expand_token(t_token *tokens)
 		{
 			new = strjoin_free(new, convert_words(str, &str, tokens), T_WORDS);
 			if (!*new)
-				return (remove_word(tokens));
+				return (remove_word(tokens, new));
 		}
 		validate_escape(*str, &flag);
 	}
@@ -66,7 +68,7 @@ void		expand_tokens(void *content)
 	while (tokens)
 	{
 		if (!*tokens->word)
-			remove_word(tokens);
+			remove_word(tokens, NULL);
 		else
 			expand_token(tokens);
 		tokens = tokens->next;


### PR DESCRIPTION
@tkomatsu 
#133 の一部対応をしたので、確認お願いします。
### 発生したメモリリーク
- 1 bytes in 1 blocks are definitely lost in loss record 1 of 58
　→このPRで修正。
- 2,048 bytes in 1 blocks are definitely lost in loss record 56 of 58
　→謎のメモリリーク。再度git cloneしたらなぜか消えたが不安要素。
### 対応内容
- convert_wordの処理直後、newが空文字列ならreturnを返す。
- このときに、newをfreeしていないためメモリリークが発生。
- newをfreeする処理を追加。

