### PR TITLE
fix(ft_export.c): fix memory leak

### DIFF
--- a/srcs/execute/ft_export.c
+++ b/srcs/execute/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: tkomatsu <tkomatsu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/22 23:25:58 by tkomatsu          #+#    #+#             */
-/*   Updated: 2021/02/25 19:06:08 by kefujiwa         ###   ########.fr       */
+/*   Updated: 2021/03/04 22:41:01 by kefujiwa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,14 +58,16 @@ static void	export_item(char *item)
 static void	export_list(void)
 {
 	t_list	*env;
+	t_list	*head;
 
 	sort_ascii(&env);
+	head = env;
 	while (env)
 	{
 		export_item(env->content);
 		env = env->next;
 	}
-	ft_lstclear(&env, nop);
+	ft_lstclear(&head, nop);
 }
 
 int			ft_export(char **args)


### PR DESCRIPTION
@tkomatsu 
度々のメモリリークの改修で大変恐縮ですが、こちらもご確認お願いします。。
`export` でメモリリークを起こしていたので修正しました。

- export コマンドの一覧をソートする際に生成したt_listが正常にフリーできていなかったため、修正。